### PR TITLE
correct colors for the privacy status indicator

### DIFF
--- a/wagtail/admin/static_src/wagtailadmin/scss/components/_formatters.scss
+++ b/wagtail/admin/static_src/wagtailadmin/scss/components/_formatters.scss
@@ -132,7 +132,7 @@ button.status-tag:hover {
     .label-public {
         &:before {
             font-size: 1.5em;
-            color: $color-teal;
+            color: $color-header-bg;
         }
     }
 

--- a/wagtail/admin/static_src/wagtailadmin/scss/components/_listing.scss
+++ b/wagtail/admin/static_src/wagtailadmin/scss/components/_listing.scss
@@ -442,6 +442,7 @@ table.listing {
             position: absolute;
             right: 10%;
             top: 2em;
+            color: $color-white;
             // @media screen and (min-width: $breakpoint-desktop-larger) {
             //     right: 20em;
             // }


### PR DESCRIPTION
Tiny modification to the scss to make the privacy indicator comply with the improved contrast.

-The privacy-indicator icon will assume the same color as the header background
-The word "Privacy" will now be white instead of inheariting some dark gray.